### PR TITLE
Apply `0 auto` margin to img tag (centers block-level images)

### DIFF
--- a/Content/site.css
+++ b/Content/site.css
@@ -18,6 +18,7 @@ body {
 img {
     max-width: 100%;
     display: block;
+    margin: 0 auto;
 }
 .bernie-calc {
     padding-top: 100px;


### PR DESCRIPTION
This will ensure the banner "Medicare For All" image is centered at all display widths.

[Preview here.](http://arielkirkwood.com/SandersHealthcareCalculator/)

Thank you for making this an open-source effort!
