### PR TITLE
Remove politically charged vernacular from UI

### DIFF
--- a/Scripts/site.js
+++ b/Scripts/site.js
@@ -18,7 +18,7 @@ $(function(){
         api.openPopup('facebook');
       }
     });
-    
+
     // data-toggle tooltip
     $('[data-toggle="tooltip"]').tooltip()
 
@@ -70,7 +70,7 @@ $(function(){
                 { 'width':''})
         }
 	})
-	
+
 	$('#deductiblePercentage').slider({
 		formatter: function(value) {
 			return (value * 100).toFixed(0) + "%";
@@ -108,7 +108,7 @@ $(function(){
             text: 'Healthcare Cost Comparison'
         },
         xAxis: {
-            categories: ['Obamacare', 'Medicare For All'],
+            categories: ['Affordable Care Act', 'Medicare For All'],
             minPadding:0,
             maxPadding:0
         },
@@ -252,7 +252,7 @@ $(function(){
             borderColor: '#000000'
         }, {
             id: 'obamacarePenalty',
-            name: 'Obamacare Penalty',
+            name: 'Affordable Care Act Penalty',
             color: '#cc0000',
             data: [0, 0],
             showInLegend: false,
@@ -312,10 +312,10 @@ $(function(){
     //$('.currency').before("<div class='dollarSign'>$</div>");
 	var taxTable = [];
 
-	var jsModel = { 
-		income: 50000, 
-		incomeShortCapGains: 0, 
-		incomeLongCapGains: 0, 
+	var jsModel = {
+		income: 50000,
+		incomeShortCapGains: 0,
+		incomeLongCapGains: 0,
 		filingStatus:1,
 		selfEmployed: 0,
 		adults: 2,

--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
         <link href="Content/animate.css" rel="stylesheet" />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
         <link href="Content/site.css" rel="stylesheet" />
-        
+
         <link rel="shortcut icon" href="https://berniesanders.com/wp-content/themes/berniesanders2016/favicon.ico">
-        
+
 
         <meta property="og:url"           content="valadian.github.io/SandersHealthcareCalculator" />
         <meta property="og:type"          content="website" />
@@ -32,12 +32,12 @@
           ga('send', 'pageview');
 
         </script>
-        
+
     </head>
 	<body class="bernie-calc">
-        
+
         <div class="navbar navbar-inverse navbar-fixed-top">
-            
+
             <div class="container">
                 <div class="row">
                     <div class="col-md-12">
@@ -47,7 +47,7 @@
                     </div>
                 </div>
             </div>
-            
+
         </div>
         <div class="body-content">
             <form>
@@ -60,16 +60,16 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="container">
                     <div class="row">
                         <div class="col-md-12">
                             <h1 class="text-center title">Healthcare Calculator</h1><br />
-                            
+
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="container-fluid bern-calc-body">
                     <div class="clearfix">
                         <!-- Col 2 -->
@@ -130,7 +130,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                         <!-- Col 8 -->
                         <div class="col-md-8">
                             <div class="row">
@@ -213,7 +213,7 @@
                                         </fieldset>
                                     </div>
                                     <div class="panel-footer">
-                                      
+
                                         <div class="advanced-toggle rounded pull-right">
                                             Advanced
                                             <span class="glyphicon glyphicon-chevron-down"></span>
@@ -276,7 +276,7 @@
                                         </fieldset>
 
                                         <fieldset class="form-group" data-bind="visible: insured()==3">
-                                            <label for="acaSubsidy">Obamacare Subsidies:</label>
+                                            <label for="acaSubsidy">Affordable Care Act Subsidies:</label>
                                             <div class="input-group">
                                                 <input data-bind="value: acaSubsidy"
                                                        class="form-control currency"
@@ -289,7 +289,7 @@
                                             <div class="input-group">
                                                 <div class="input-group-addon info whoLabel">Employee</div>
                                                 <input data-bind="value: premium, enable: hasInsurance(),
-                                                    tooltip: {title: 'Premiums paid by YOU minus any Obamacare subsidies', trigger: 'focus' }"
+                                                    tooltip: {title: 'Premiums paid by YOU minus any Affordable Care Act subsidies', trigger: 'focus' }"
                                                        class="form-control currency" placeholder="Enter Insurance Premium"
                                                        name="premium" />
                                                 <select class="form-control" data-bind="value: premiumPeriod, enable: hasInsurance()">
@@ -375,7 +375,7 @@
                                         <!--<fieldset class="form-group">-->
                                         <!--<div class="col-md-6">-->
                                             <!--<div class="row bernieReplacing">-->
-                                                <!--<h3 class="text-center">ObamaCare</h3>-->
+                                                <!--<h3 class="text-center">Affordable Care Act</h3>-->
                                                 <!--<hr/>-->
                                                 <!--<div class="col-xs-6 ">-->
                                                     <!--<div class="result-panel">-->
@@ -600,7 +600,7 @@
                         </div>
                     </div>
                 </div>
-               
+
             </form> <!-- ./End form -->
         </div> <!-- ./End contanier-fluid -->
         <div class="quote">
@@ -632,7 +632,7 @@
                         <p>Calculated according to
                             <a href="https://berniesanders.com/wp-content/uploads/2016/01/Medicare-for-All.pdf" target="_blank">
                                 Medicare for All PDF
-                            </a> 
+                            </a>
                             Released by Bernie's campaign on 1/17/2016
                         </p>
                     </div>
@@ -645,7 +645,7 @@
                         </div>
                     </div>
                 </div>
-            </div> 
+            </div>
         </footer>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
         <!-- Load Facebook SDK for JavaScript -->


### PR DESCRIPTION
Obamacare is a politically charged and motived word that has imprecise meaning. Obamacare has been use to describe everything from the plan he started with, to the compromised and passed act we have now under PPACA. During this process the word was used discredit the viability of the act by distracting the populous from its merit to more ad hominem style attacks. 

With this in mind I would like to move to a more precise and accurate phrase, Affordable Care Act. 
